### PR TITLE
AliceLG - Configurable grpc timeout for GoBGP backends

### DIFF
--- a/backend/sources/gobgp/config.go
+++ b/backend/sources/gobgp/config.go
@@ -4,8 +4,10 @@ type Config struct {
 	Id   string
 	Name string
 
-	Host          string `ini:"host"`
-	Insecure      bool   `ini:"insecure"`
-	TLSCert       string `ini:"tls_crt"`
-	TLSCommonName string `ini:"tls_common_name"`
+	Host     string `ini:"host"`
+	Insecure bool   `ini:"insecure"`
+	// ProcessingTimeout is a timeout configured per gRPC call to a given GoBGP backend
+	ProcessingTimeout int    `ini:"processing_timeout"`
+	TLSCert           string `ini:"tls_crt"`
+	TLSCommonName     string `ini:"tls_common_name"`
 }

--- a/backend/sources/gobgp/routes.go
+++ b/backend/sources/gobgp/routes.go
@@ -48,7 +48,7 @@ func (gobgp *GoBGP) lookupNeighbour(neighborId string) (*gobgpapi.Peer, error) {
 }
 
 func (gobgp *GoBGP) GetNeighbours() ([]*gobgpapi.Peer, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(gobgp.config.ProcessingTimeout))
 	defer cancel()
 
 	peerStream, err := gobgp.client.ListPeer(ctx, &gobgpapi.ListPeerRequest{EnableAdvertised: true})
@@ -144,7 +144,7 @@ func (gobgp *GoBGP) parsePathIntoRoute(path *gobgpapi.Path, prefix string) (erro
 }
 
 func (gobgp *GoBGP) GetRoutes(peer *gobgpapi.Peer, tableType gobgpapi.TableType, response *api.RoutesResponse) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(gobgp.config.ProcessingTimeout))
 	defer cancel()
 
 	for _, family := range families {

--- a/backend/sources/gobgp/source.go
+++ b/backend/sources/gobgp/source.go
@@ -88,7 +88,7 @@ func (gobgp *GoBGP) ExpireCaches() int {
 }
 
 func (gobgp *GoBGP) NeighboursStatus() (*api.NeighboursStatusResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(gobgp.config.ProcessingTimeout))
 	defer cancel()
 
 	response := api.NeighboursStatusResponse{}
@@ -123,7 +123,7 @@ func (gobgp *GoBGP) NeighboursStatus() (*api.NeighboursStatusResponse, error) {
 }
 
 func (gobgp *GoBGP) Status() (*api.StatusResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(gobgp.config.ProcessingTimeout))
 	defer cancel()
 
 	resp, err := gobgp.client.GetBgp(ctx, &gobgpapi.GetBgpRequest{})
@@ -138,7 +138,7 @@ func (gobgp *GoBGP) Status() (*api.StatusResponse, error) {
 }
 
 func (gobgp *GoBGP) Neighbours() (*api.NeighboursResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(gobgp.config.ProcessingTimeout))
 	defer cancel()
 
 	response := api.NeighboursResponse{}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/alice-lg/alice-lg
 
+go 1.14
+
 require (
 	github.com/GeertJohan/go.rice v0.0.0-20181229193832-0af3f3b09a0a
 	github.com/daaku/go.zipexe v0.0.0-20150329023125-a5fe2436ffcb // indirect


### PR DESCRIPTION
Alice-LG has an integration to query neighbors and their routes from a GoBGP backend. This integration makes use of Google's RPC language/interface (https://grpc.io/), where Alice-LG is the client and the backend GoBGP instance is the server.

As currently implemented, there is one second timeout for any given gRPC request made by Alice-LG's backend to the remote GoBGP backend. This timeout can be see on: https://github.com/alice-lg/alice-lg/blob/master/backend/sources/gobgp/routes.go#L51 and anywhere else where ctx, cancel := context.WithTimeout(context.Background(), time.Second) is used (also on https://github.com/alice-lg/alice-lg/blob/master/backend/sources/gobgp/source.go).

I would like to make this a configurable timeout from https://github.com/alice-lg/alice-lg/blob/master/backend/sources/gobgp/config.go so that a user could adjust as needed. In my situation, I needed to increase the timeout well above 30 seconds to avoid timeout related errors (remotely deployed GoBGP instances containing large numbers of routes).

Example configuration for a GoBGP backend making use of this new configuration option:
```
[source.router1.gobgp]
api = 10.1.1.1:50051
host = 10.1.1.1:50051
insecure = true
processing_timeout = 30
# single_table / multi_table
type = multi_table
peer_table_prefix = T
pipe_protocol_prefix = M
# Timeout in seconds to wait for the status data (only required if enable_neighbors_status_refresh is true)
neighbors_refresh_timeout = 2
```
