### PR TITLE
Upstream "make test" to Alice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,7 @@ clean:
 	rm -f bin/alice-lg-linux-amd64
 	rm -f bin/alice-lg-osx-amd64
 	rm -rf $(DIST)
+
+
+test:
+	go test -v -race -cover ./...

--- a/backend/sources/gobgp/utils.go
+++ b/backend/sources/gobgp/utils.go
@@ -17,7 +17,7 @@ func PeerHash(peer *api.Peer) string {
 
 func PeerHashWithASAndAddress(asn uint32, address string) string {
 	h := sha1.New()
-	io.WriteString(h, string(asn))
+	io.WriteString(h, fmt.Sprint(asn))
 	io.WriteString(h, address)
 	sum := h.Sum(nil)
 	return fmt.Sprintf("%x", sum[0:5])


### PR DESCRIPTION
This pull request adds a new `test` command to Alice's Makefile, allowing one to execute all tests using `make test`.  In addition, I would like to suggest that future PRs requires a successful `make test` before merging into master.

This PR also corrects an issue discovered by the current set of tests where a value was being cast to a string incorrectly.

**Before:**
```
...alice-lg$ go test ./...
# github.com/alice-lg/alice-lg/backend/sources/gobgp
backend/sources/gobgp/utils.go:20:20: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
ok      github.com/alice-lg/alice-lg/backend    (cached)
ok      github.com/alice-lg/alice-lg/backend/api        (cached)
ok      github.com/alice-lg/alice-lg/backend/caches     (cached)
?       github.com/alice-lg/alice-lg/backend/sources    [no test files]
ok      github.com/alice-lg/alice-lg/backend/sources/birdwatcher        (cached)
ok      github.com/alice-lg/alice-lg/backend/sources/gobgp/apiutil      (cached)

...alice-lg$ echo $?
2
```

**After:**
```
...alice-lg$ go test ./...
ok      github.com/alice-lg/alice-lg/backend    (cached)
ok      github.com/alice-lg/alice-lg/backend/api        (cached)
ok      github.com/alice-lg/alice-lg/backend/caches     (cached)
?       github.com/alice-lg/alice-lg/backend/sources    [no test files]
ok      github.com/alice-lg/alice-lg/backend/sources/birdwatcher        (cached)
?       github.com/alice-lg/alice-lg/backend/sources/gobgp      [no test files]
ok      github.com/alice-lg/alice-lg/backend/sources/gobgp/apiutil      (cached)

...alice-lg$ echo $?
0
```


**Full output from `make test`:**
```
...alice-lg$ make test

go test -v -race -cover ./...
=== RUN   TestApiLogSourceError
2021/04/15 10:56:54 API ERROR :: rs1.example.net (IPv4).foo.bar(23, Test)
2021/04/15 10:56:54 API ERROR :: rs1.example.net (IPv4).foo.bam() :: an unexpected error occured
2021/04/15 10:56:54 API ERROR :: rs1.example.net (IPv4).foo.baz(23, 42, foo) :: an unexpected error occured
--- PASS: TestApiLogSourceError (0.00s)
=== RUN   TestApiRoutesPagination
--- PASS: TestApiRoutesPagination (0.00s)
=== RUN   TestApiQueryFilterNextHopGateway
--- PASS: TestApiQueryFilterNextHopGateway (0.00s)
=== RUN   TestCommunityLookup
--- PASS: TestCommunityLookup (0.00s)
=== RUN   TestSetCommunity
--- PASS: TestSetCommunity (0.00s)
=== RUN   TestWildcardLookup
--- PASS: TestWildcardLookup (0.00s)
=== RUN   TestLoadConfigs
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestLoadConfigs (0.00s)
=== RUN   TestSourceConfig
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestSourceConfig (0.00s)
=== RUN   TestSourceConfigDefaultsOverride
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestSourceConfigDefaultsOverride (0.00s)
=== RUN   TestRejectAndNoexportReasons
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestRejectAndNoexportReasons (0.00s)
=== RUN   TestBlackholeParsing
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestBlackholeParsing (0.00s)
=== RUN   TestOwnASN
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestOwnASN (0.00s)
=== RUN   TestRpkiConfig
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
    config_test.go:203: {true [23042 1000 1] [23042 1000 2] [9033 1000 3] [23042 1000 4 *]}
--- PASS: TestRpkiConfig (0.00s)
=== RUN   TestRejectCandidatesConfig
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/15 10:56:54 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
    config_test.go:213: map[23:map[42:map[46:reject-candidate-3]] 6695:map[1102:map[14:reject-candidate-1 15:reject-candidate-2]]]
--- PASS: TestRejectCandidatesConfig (0.00s)
=== RUN   TestGetSourceState
--- PASS: TestGetSourceState (0.00s)
=== RUN   TestGetNeighbourAt
--- PASS: TestGetNeighbourAt (0.00s)
=== RUN   TestGetNeighbors
--- PASS: TestGetNeighbors (0.00s)
=== RUN   TestNeighbourLookupAt
--- PASS: TestNeighbourLookupAt (0.00s)
=== RUN   TestNeighbourLookup
--- PASS: TestNeighbourLookup (0.00s)
=== RUN   TestNeighborFilter
--- PASS: TestNeighborFilter (0.00s)
=== RUN   TestRoutesStoreStats
--- PASS: TestRoutesStoreStats (0.08s)
=== RUN   TestLookupPrefixAt
--- PASS: TestLookupPrefixAt (0.09s)
=== RUN   TestLookupPrefix
--- PASS: TestLookupPrefix (0.09s)
=== RUN   TestLookupNeighboursPrefixesAt
--- PASS: TestLookupNeighboursPrefixesAt (0.08s)
=== RUN   TestLookupPrefixForNeighbours
--- PASS: TestLookupPrefixForNeighbours (0.09s)
=== RUN   TestThemeFiles
--- PASS: TestThemeFiles (0.00s)
=== RUN   TestThemeIncludeHash
    theme_test.go:77: Filehash: 60787e66
--- PASS: TestThemeIncludeHash (0.00s)
=== RUN   TestThemeIncludes
--- PASS: TestThemeIncludes (0.00s)
=== RUN   TestContainsCi
--- PASS: TestContainsCi (0.00s)
=== RUN   TestMaybePrefix
--- PASS: TestMaybePrefix (0.00s)
=== RUN   TestTrimmedStringList
--- PASS: TestTrimmedStringList (0.00s)
PASS
coverage: 40.5% of statements
ok  	github.com/alice-lg/alice-lg/backend	(cached)	coverage: 40.5% of statements
=== RUN   TestStatusResponseSerialization
--- PASS: TestStatusResponseSerialization (0.00s)
=== RUN   TestNeighbourSerialization
--- PASS: TestNeighbourSerialization (0.00s)
=== RUN   TestCommunityStringify
--- PASS: TestCommunityStringify (0.00s)
=== RUN   TestHasCommunity
--- PASS: TestHasCommunity (0.00s)
=== RUN   TestUniqueCommunities
    response_test.go:131: All: [23:42 42:123 23:42] Unique: [23:42 42:123]
--- PASS: TestUniqueCommunities (0.00s)
=== RUN   TestUniqueExtCommunities
    response_test.go:143: All: [rt:23:42 ro:42:123 rt:23:42] Unique: [rt:23:42 ro:42:123]
--- PASS: TestUniqueExtCommunities (0.00s)
=== RUN   TestParseQueryValueIntList
--- PASS: TestParseQueryValueIntList (0.00s)
=== RUN   TestParseCommunityValueList
--- PASS: TestParseCommunityValueList (0.00s)
=== RUN   TestParseExtCommunityValue
--- PASS: TestParseExtCommunityValue (0.00s)
=== RUN   TestSearchFilterCmpInt
--- PASS: TestSearchFilterCmpInt (0.00s)
=== RUN   TestSearchFilterCmpCommunity
--- PASS: TestSearchFilterCmpCommunity (0.00s)
=== RUN   TestSearchFilterEqual
--- PASS: TestSearchFilterEqual (0.00s)
=== RUN   TestSearchFilterGroupContains
--- PASS: TestSearchFilterGroupContains (0.00s)
=== RUN   TestSearchFilterGetGroupsByKey
--- PASS: TestSearchFilterGetGroupsByKey (0.00s)
=== RUN   TestSearchFilterManagement
--- PASS: TestSearchFilterManagement (0.00s)
=== RUN   TestSearchFiltersFromQuery
    search_filters_test.go:258: 23:42:42
--- PASS: TestSearchFiltersFromQuery (0.00s)
=== RUN   TestSearchFilterCompareRoute
--- PASS: TestSearchFilterCompareRoute (0.00s)
=== RUN   TestSearchFilterMatchRoute
--- PASS: TestSearchFilterMatchRoute (0.00s)
=== RUN   TestSearchFilterExcludeRoute
--- PASS: TestSearchFilterExcludeRoute (0.00s)
=== RUN   TestSearchFilterLookupRouteCommunity
--- PASS: TestSearchFilterLookupRouteCommunity (0.00s)
=== RUN   TestSearchFilterRouteExtCommunities
--- PASS: TestSearchFilterRouteExtCommunities (0.00s)
=== RUN   TestSearchFilterLookupRouteExtCommunities
--- PASS: TestSearchFilterLookupRouteExtCommunities (0.00s)
=== RUN   TestSearchFilterRouteLargeCommunities
--- PASS: TestSearchFilterRouteLargeCommunities (0.00s)
=== RUN   TestSearchFilterLookupRouteLargeCommunities
--- PASS: TestSearchFilterLookupRouteLargeCommunities (0.00s)
=== RUN   TestSearchFiltersSub
    search_filters_test.go:526: &[0xc00021b9b0 0xc00021b9e0 0xc00021ba10 0xc00021ba40 0xc00021ba70]
    search_filters_test.go:527: &[0xc00021bd70 0xc00021bda0 0xc00021bdd0 0xc00021be00 0xc00021be30]
--- PASS: TestSearchFiltersSub (0.00s)
=== RUN   TestSearchFiltersMergeProperties
--- PASS: TestSearchFiltersMergeProperties (0.00s)
=== RUN   TestNeighborFilterMatch
--- PASS: TestNeighborFilterMatch (0.00s)
=== RUN   TestNeighborFilterFromQuery
--- PASS: TestNeighborFilterFromQuery (0.00s)
PASS
coverage: 77.6% of statements
ok  	github.com/alice-lg/alice-lg/backend/api	(cached)	coverage: 77.6% of statements
=== RUN   TestLRUMap
--- PASS: TestLRUMap (0.00s)
=== RUN   TestNeighborsCacheSetGet
--- PASS: TestNeighborsCacheSetGet (0.03s)
=== RUN   TestRoutesCacheSetGet
--- PASS: TestRoutesCacheSetGet (0.04s)
=== RUN   TestRoutesCacheLru
--- PASS: TestRoutesCacheLru (0.00s)
PASS
coverage: 74.5% of statements
ok  	github.com/alice-lg/alice-lg/backend/caches	(cached)	coverage: 74.5% of statements
?   	github.com/alice-lg/alice-lg/backend/sources	[no test files]
=== RUN   Test_ParseApiStatus
--- PASS: Test_ParseApiStatus (0.00s)
=== RUN   Test_NeighboursParsing
--- PASS: Test_NeighboursParsing (0.00s)
=== RUN   Test_RoutesParsing
--- PASS: Test_RoutesParsing (0.00s)
=== RUN   Test_ParseServerTime
--- PASS: Test_ParseServerTime (0.00s)
=== RUN   TestGetMasterPipeName
--- PASS: TestGetMasterPipeName (0.00s)
PASS
coverage: 16.1% of statements
ok  	github.com/alice-lg/alice-lg/backend/sources/birdwatcher	(cached)	coverage: 16.1% of statements
?   	github.com/alice-lg/alice-lg/backend/sources/gobgp	[no test files]
=== RUN   Test_OriginAttribute
--- PASS: Test_OriginAttribute (0.00s)
=== RUN   Test_AsPathAttribute
--- PASS: Test_AsPathAttribute (0.00s)
=== RUN   Test_NextHopAttribute
--- PASS: Test_NextHopAttribute (0.00s)
=== RUN   Test_MultiExitDiscAttribute
--- PASS: Test_MultiExitDiscAttribute (0.00s)
=== RUN   Test_LocalPrefAttribute
--- PASS: Test_LocalPrefAttribute (0.00s)
=== RUN   Test_AtomicAggregateAttribute
--- PASS: Test_AtomicAggregateAttribute (0.00s)
=== RUN   Test_AggregatorAttribute
--- PASS: Test_AggregatorAttribute (0.00s)
=== RUN   Test_CommunitiesAttribute
--- PASS: Test_CommunitiesAttribute (0.00s)
=== RUN   Test_OriginatorIdAttribute
--- PASS: Test_OriginatorIdAttribute (0.00s)
=== RUN   Test_ClusterListAttribute
--- PASS: Test_ClusterListAttribute (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_UC
--- PASS: Test_MpReachNLRIAttribute_IPv4_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_UC
--- PASS: Test_MpReachNLRIAttribute_IPv6_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_MPLS
--- PASS: Test_MpReachNLRIAttribute_IPv4_MPLS (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_MPLS
--- PASS: Test_MpReachNLRIAttribute_IPv6_MPLS (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_ENCAP
--- PASS: Test_MpReachNLRIAttribute_IPv4_ENCAP (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_ENCAP
--- PASS: Test_MpReachNLRIAttribute_IPv6_ENCAP (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_AD_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_AD_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_MAC_IP_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_MAC_IP_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_MC_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_MC_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_ES_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_ES_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_Prefix_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_Prefix_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_VPN
--- PASS: Test_MpReachNLRIAttribute_IPv4_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_VPN
--- PASS: Test_MpReachNLRIAttribute_IPv6_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_RTC_UC
--- PASS: Test_MpReachNLRIAttribute_RTC_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv4_UC
--- PASS: Test_MpReachNLRIAttribute_FS_IPv4_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv4_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_IPv4_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv6_UC
--- PASS: Test_MpReachNLRIAttribute_FS_IPv6_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv6_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_IPv6_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_L2_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_L2_VPN (0.00s)
=== RUN   Test_MpUnreachNLRIAttribute_IPv4_UC
--- PASS: Test_MpUnreachNLRIAttribute_IPv4_UC (0.00s)
=== RUN   Test_ExtendedCommunitiesAttribute
--- PASS: Test_ExtendedCommunitiesAttribute (0.00s)
=== RUN   Test_As4PathAttribute
--- PASS: Test_As4PathAttribute (0.00s)
=== RUN   Test_As4AggregatorAttribute
--- PASS: Test_As4AggregatorAttribute (0.00s)
=== RUN   Test_PmsiTunnelAttribute
--- PASS: Test_PmsiTunnelAttribute (0.00s)
=== RUN   Test_TunnelEncapAttribute
--- PASS: Test_TunnelEncapAttribute (0.00s)
=== RUN   Test_IP6ExtendedCommunitiesAttribute
--- PASS: Test_IP6ExtendedCommunitiesAttribute (0.00s)
=== RUN   Test_AigpAttribute
--- PASS: Test_AigpAttribute (0.00s)
=== RUN   Test_LargeCommunitiesAttribute
--- PASS: Test_LargeCommunitiesAttribute (0.00s)
=== RUN   Test_UnknownAttribute
--- PASS: Test_UnknownAttribute (0.00s)
=== RUN   Test_MultiProtocolCapability
--- PASS: Test_MultiProtocolCapability (0.00s)
=== RUN   Test_RouteRefreshCapability
--- PASS: Test_RouteRefreshCapability (0.00s)
=== RUN   Test_CarryingLabelInfoCapability
--- PASS: Test_CarryingLabelInfoCapability (0.00s)
=== RUN   Test_ExtendedNexthopCapability
--- PASS: Test_ExtendedNexthopCapability (0.00s)
=== RUN   Test_GracefulRestartCapability
--- PASS: Test_GracefulRestartCapability (0.00s)
=== RUN   Test_FourOctetASNumberCapability
--- PASS: Test_FourOctetASNumberCapability (0.00s)
=== RUN   Test_AddPathCapability
--- PASS: Test_AddPathCapability (0.00s)
=== RUN   Test_EnhancedRouteRefreshCapability
--- PASS: Test_EnhancedRouteRefreshCapability (0.00s)
=== RUN   Test_LongLivedGracefulRestartCapability
--- PASS: Test_LongLivedGracefulRestartCapability (0.00s)
=== RUN   Test_RouteRefreshCiscoCapability
--- PASS: Test_RouteRefreshCiscoCapability (0.00s)
=== RUN   Test_UnknownCapability
--- PASS: Test_UnknownCapability (0.00s)
PASS
coverage: 67.8% of statements
ok  	github.com/alice-lg/alice-lg/backend/sources/gobgp/apiutil	(cached)	coverage: 67.8% of statements
```