### PR TITLE
Remove trailing slash to avoid redirect on Birdwatcher's routes_pipe_filtered endpoint

### DIFF
--- a/pkg/sources/birdwatcher/source_multitable.go
+++ b/pkg/sources/birdwatcher/source_multitable.go
@@ -147,7 +147,7 @@ func (self *MultiTableBirdwatcher) fetchFilteredRoutes(neighborId string) (*api.
 	}
 
 	// Query birdwatcher
-	birdPipeFiltered, err := self.client.GetJson("/routes/pipe/filtered/?table=" + table + "&pipe=" + pipeName)
+	birdPipeFiltered, err := self.client.GetJson("/routes/pipe/filtered?table=" + table + "&pipe=" + pipeName)
 	if err != nil {
 		log.Println("WARNING Could not retrieve filtered routes:", err)
 		log.Println("Is the 'pipe_filtered' module active in birdwatcher?")


### PR DESCRIPTION
There is a trailing slash when Alice tries to read from Birdwatcher's `routes_pipe_filtered` endpoint:

```
$ curl -i "http://192.168.245.172:8080/routes/pipe/filtered/?table=foo&pipe=bar"
HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=utf-8
Location: /routes/pipe/filtered?table=foo&pipe=bar
Date: Sat, 17 Apr 2021 04:20:26 GMT
Content-Length: 79

<a href="/routes/pipe/filtered?table=foo&amp;pipe=bar">Moved Permanently</a>.

$ curl -i "http://192.168.245.172:8080/routes/pipe/filtered?table=foo&pipe=bar"
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sat, 17 Apr 2021 04:20:29 GMT
Content-Length: 260

{"api":{"Version":"2.0.0","result_from_cache":false,"cache_status":{"cached_at":{"date":"2021-04-17T04:20:29.983958738Z","timezone_type":"UTC","timezone":"UTC"}}},"cached_at":"2021-04-17T04:20:29.983958738Z","routes":[],"ttl":"2021-04-17T04:25:29.983958738Z"}
```

This change removes that trailing slash to avoid the additional redirect.