### PR TITLE
AliceLG - Configurable HTTP Timeout

### DIFF
--- a/etc/alice-lg/alice.example.conf
+++ b/etc/alice-lg/alice.example.conf
@@ -5,6 +5,8 @@
 [server]
 # configures the built-in webserver and provides global application settings
 listen_http = 127.0.0.1:7340
+# configures the built-in webserver timeout in seconds (default 10)
+# http_timeout = 60
 # enable the prefix-lookup endpoint / the global search feature
 enable_prefix_lookup = true
 # Try to refresh the neighbor status on every request to /neighbors

--- a/pkg/backend/api_server.go
+++ b/pkg/backend/api_server.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -23,6 +24,17 @@ func StartHTTPServer() {
 		log.Fatal(err)
 	}
 
+	httpTimeout := time.Duration(AliceConfig.Server.HttpTimeout) * time.Second
+	log.Println("Web server HTTP timeout set to:", httpTimeout)
+
+	server := &http.Server{
+		Addr:         AliceConfig.Server.Listen,
+		Handler:      router,
+		ReadTimeout:  httpTimeout,
+		WriteTimeout: httpTimeout,
+		IdleTimeout:  httpTimeout,
+	}
+
 	// Start http server
-	log.Fatal(http.ListenAndServe(AliceConfig.Server.Listen, router))
+	log.Fatal(server.ListenAndServe())
 }

--- a/pkg/backend/config.go
+++ b/pkg/backend/config.go
@@ -23,12 +23,14 @@ const (
 // A ServerConfig holds the runtime configuration
 // for the backend.
 type ServerConfig struct {
-	Listen                         string `ini:"listen_http"`
-	EnablePrefixLookup             bool   `ini:"enable_prefix_lookup"`
-	NeighboursStoreRefreshInterval int    `ini:"neighbours_store_refresh_interval"`
-	RoutesStoreRefreshInterval     int    `ini:"routes_store_refresh_interval"`
-	Asn                            int    `ini:"asn"`
-	EnableNeighborsStatusRefresh   bool   `ini:"enable_neighbors_status_refresh"`
+	Listen string `ini:"listen_http"`
+	// HttpTimeout is a timeout in seconds
+	HttpTimeout                    int  `ini:"http_timeout"`
+	EnablePrefixLookup             bool `ini:"enable_prefix_lookup"`
+	NeighboursStoreRefreshInterval int  `ini:"neighbours_store_refresh_interval"`
+	RoutesStoreRefreshInterval     int  `ini:"routes_store_refresh_interval"`
+	Asn                            int  `ini:"asn"`
+	EnableNeighborsStatusRefresh   bool `ini:"enable_neighbors_status_refresh"`
 }
 
 // HousekeepingConfig describes the housekeeping interval
@@ -717,6 +719,11 @@ func loadConfig(file string) (*Config, error) {
 	// Map sections
 	server := ServerConfig{}
 	parsedConfig.Section("server").MapTo(&server)
+
+	// Set default http timeout when not configured
+	if server.HttpTimeout == 0 {
+		server.HttpTimeout = 10
+	}
 
 	housekeeping := HousekeepingConfig{}
 	parsedConfig.Section("housekeeping").MapTo(&housekeeping)


### PR DESCRIPTION
When AliceLG is connected to BIRD instances containing full Internet routing tables, a search from the main landing page often results in a "504 Timeout" error.  In debugging Alice, I found that the default HTTP timeout was 10 seconds provided by Golang's `http` library when invoking `http.ListenAndServe()`.  This pull request adds a new config option under the `[server]` section named `http_timeout` to allow one to configure a custom HTTP timeout.  When not configured, the default is set to 10 seconds.

One search that I tested took 24 seconds to complete.  Several others took ~ 30 seconds.

# Testing:
### Web UI
With this change, and with a timeout configured for 300 seconds, a search from the main landing page works great.  I no longer see timeouts.

### Local Console Logs
```
go build && ./alice-lg --config ~/code/birdwatcher_env/config/alice/alice2.conf
2021/04/20 15:25:16 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
        **        ***               Alice unknown
     *****         ***      *
    *  ***          **     ***      Listening on: 0.0.0.0:7340
       ***          **      *       Routeservers: 1
      *  **         **
      *  **         **    ***        ****       ***
     *    **        **     ***      * ***  *   * ***
     *    **        **      **     *   ****   *   ***
    *      **       **      **    **         **    ***
    *********       **      **    **         ********
   *        **      **      **    **         *******
   *        **      **      **    **         **
  *****      **     **      **    ***     *  ****    *
 *   ****    ** *   *** *   *** *  *******    *******
*     **      **     ***     ***    *****      *****
*
 **
2021/04/20 15:25:16 Using configuration: alice.conf
2021/04/20 15:25:16 Preparing and installing assets
2021/04/20 15:25:16 Starting local neighbours store
2021/04/20 15:25:16 Using theme at: <removed>
2021/04/20 15:25:16 Neighbours Store refresh interval set to: 5m0s
2021/04/20 15:25:16 Starting local routes store
2021/04/20 15:25:16 Web server HTTP timeout set to: 10s
2021/04/20 15:25:16 Routes Store refresh interval set to: 5m0s
2021/04/20 15:25:16 Refreshed neighbors store for 1 of 1 sources with 0 error(s) in 11.322503ms
2021/04/20 15:25:16 Neighbours store:
2021/04/20 15:25:16     Neighbours: 2
2021/04/20 15:25:16       - tst1-host01 (IPv4)
2021/04/20 15:25:16         State: READY
2021/04/20 15:25:16         UpdatedAt: 2021-04-20 15:25:16.743911 -0700 PDT m=+0.016529388
2021/04/20 15:25:16         Neighbours: 2
2021/04/20 15:25:16 Refreshed routes store for 1 of 1 sources with 0 error(s) in 43.02407ms
2021/04/20 15:25:16 Routes store:
2021/04/20 15:25:16     Routes Imported: 3 Filtered: 0
2021/04/20 15:25:16     Routeservers:
2021/04/20 15:25:16       - tst1-host01 (IPv4)
2021/04/20 15:25:16         State: READY
2021/04/20 15:25:16         UpdatedAt: 2021-04-20 15:25:16.775804 -0700 PDT m=+0.048421239
2021/04/20 15:25:16         Routes Imported: 3 Filtered: 0
```

### Unit Tests
```
go test ./... -v

=== RUN   TestPresenceOfIndexHTML
    assets_test.go:12: <!DOCTYPE html>
        <html>
          <head>
            <title>Alice - The friendly BGP looking glass</title>
            <meta charset="utf-8" />
            <meta http-equiv="X-UA-Compatible" content="IE=edge" />
            <meta name="viewport" content="width=device-width, initial-scale=1" />
        
            <link rel="stylesheet" href="css/libs.min.css?APP_VERSION" />
            <link rel="stylesheet" href="css/main.css?APP_VERSION" />
        
            <!-- ###THEME_STYLESHEETS### -->
          </head>
          <body>
            <!-- Application: Birdseye -->
            <div id="app"></div>
        
            <!-- Scripts -->
            <script src="js/libs.min.js?APP_VERSION"></script>
            <script src="js/app.js?APP_VERSION"></script>
        
            <!-- ###THEME_SCRIPTS### -->
          </body>
        </html>
        
--- PASS: TestPresenceOfIndexHTML (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/client	(cached)
?   	github.com/alice-lg/alice-lg/cmd/alice-lg	[no test files]
=== RUN   TestStatusResponseSerialization
--- PASS: TestStatusResponseSerialization (0.00s)
=== RUN   TestNeighbourSerialization
--- PASS: TestNeighbourSerialization (0.00s)
=== RUN   TestCommunityStringify
--- PASS: TestCommunityStringify (0.00s)
=== RUN   TestHasCommunity
--- PASS: TestHasCommunity (0.00s)
=== RUN   TestUniqueCommunities
    response_test.go:131: All: [23:42 42:123 23:42] Unique: [23:42 42:123]
--- PASS: TestUniqueCommunities (0.00s)
=== RUN   TestUniqueExtCommunities
    response_test.go:143: All: [rt:23:42 ro:42:123 rt:23:42] Unique: [rt:23:42 ro:42:123]
--- PASS: TestUniqueExtCommunities (0.00s)
=== RUN   TestParseQueryValueIntList
--- PASS: TestParseQueryValueIntList (0.00s)
=== RUN   TestParseCommunityValueList
--- PASS: TestParseCommunityValueList (0.00s)
=== RUN   TestParseExtCommunityValue
--- PASS: TestParseExtCommunityValue (0.00s)
=== RUN   TestSearchFilterCmpInt
--- PASS: TestSearchFilterCmpInt (0.00s)
=== RUN   TestSearchFilterCmpCommunity
--- PASS: TestSearchFilterCmpCommunity (0.00s)
=== RUN   TestSearchFilterEqual
--- PASS: TestSearchFilterEqual (0.00s)
=== RUN   TestSearchFilterGroupContains
--- PASS: TestSearchFilterGroupContains (0.00s)
=== RUN   TestSearchFilterGetGroupsByKey
--- PASS: TestSearchFilterGetGroupsByKey (0.00s)
=== RUN   TestSearchFilterManagement
--- PASS: TestSearchFilterManagement (0.00s)
=== RUN   TestSearchFiltersFromQuery
    search_filters_test.go:258: 23:42:42
--- PASS: TestSearchFiltersFromQuery (0.00s)
=== RUN   TestSearchFilterCompareRoute
--- PASS: TestSearchFilterCompareRoute (0.00s)
=== RUN   TestSearchFilterMatchRoute
--- PASS: TestSearchFilterMatchRoute (0.00s)
=== RUN   TestSearchFilterExcludeRoute
--- PASS: TestSearchFilterExcludeRoute (0.00s)
=== RUN   TestSearchFilterLookupRouteCommunity
--- PASS: TestSearchFilterLookupRouteCommunity (0.00s)
=== RUN   TestSearchFilterRouteExtCommunities
--- PASS: TestSearchFilterRouteExtCommunities (0.00s)
=== RUN   TestSearchFilterLookupRouteExtCommunities
--- PASS: TestSearchFilterLookupRouteExtCommunities (0.00s)
=== RUN   TestSearchFilterRouteLargeCommunities
--- PASS: TestSearchFilterRouteLargeCommunities (0.00s)
=== RUN   TestSearchFilterLookupRouteLargeCommunities
--- PASS: TestSearchFilterLookupRouteLargeCommunities (0.00s)
=== RUN   TestSearchFiltersSub
    search_filters_test.go:526: &[0xc000191650 0xc000191680 0xc0001916b0 0xc0001916e0 0xc000191710]
    search_filters_test.go:527: &[0xc000191a10 0xc000191a40 0xc000191a70 0xc000191aa0 0xc000191ad0]
--- PASS: TestSearchFiltersSub (0.00s)
=== RUN   TestSearchFiltersMergeProperties
--- PASS: TestSearchFiltersMergeProperties (0.00s)
=== RUN   TestNeighborFilterMatch
--- PASS: TestNeighborFilterMatch (0.00s)
=== RUN   TestNeighborFilterFromQuery
--- PASS: TestNeighborFilterFromQuery (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/pkg/api	(cached)
=== RUN   TestApiLogSourceError
2021/04/20 15:23:43 API ERROR :: rs1.example.net (IPv4).foo.bar(23, Test)
2021/04/20 15:23:43 API ERROR :: rs1.example.net (IPv4).foo.bam() :: an unexpected error occured
2021/04/20 15:23:43 API ERROR :: rs1.example.net (IPv4).foo.baz(23, 42, foo) :: an unexpected error occured
--- PASS: TestApiLogSourceError (0.00s)
=== RUN   TestApiRoutesPagination
--- PASS: TestApiRoutesPagination (0.00s)
=== RUN   TestApiQueryFilterNextHopGateway
--- PASS: TestApiQueryFilterNextHopGateway (0.00s)
=== RUN   TestCommunityLookup
--- PASS: TestCommunityLookup (0.00s)
=== RUN   TestSetCommunity
--- PASS: TestSetCommunity (0.00s)
=== RUN   TestWildcardLookup
--- PASS: TestWildcardLookup (0.00s)
=== RUN   TestLoadConfigs
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestLoadConfigs (0.00s)
=== RUN   TestSourceConfig
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestSourceConfig (0.00s)
=== RUN   TestSourceConfigDefaultsOverride
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestSourceConfigDefaultsOverride (0.00s)
=== RUN   TestRejectAndNoexportReasons
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestRejectAndNoexportReasons (0.00s)
=== RUN   TestBlackholeParsing
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestBlackholeParsing (0.00s)
=== RUN   TestOwnASN
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
--- PASS: TestOwnASN (0.00s)
=== RUN   TestRpkiConfig
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
    config_test.go:188: {true [23042 1000 1] [23042 1000 2] [9033 1000 3] [23042 1000 4 *]}
--- PASS: TestRpkiConfig (0.00s)
=== RUN   TestRejectCandidatesConfig
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
2021/04/20 15:23:43 Adding birdwatcher source of type multi_table with peer_table_prefix T and pipe_protocol_prefix M
    config_test.go:198: map[23:map[42:map[46:reject-candidate-3]] 6695:map[1102:map[14:reject-candidate-1 15:reject-candidate-2]]]
--- PASS: TestRejectCandidatesConfig (0.00s)
=== RUN   TestGetSourceState
--- PASS: TestGetSourceState (0.00s)
=== RUN   TestGetNeighbourAt
--- PASS: TestGetNeighbourAt (0.00s)
=== RUN   TestGetNeighbors
--- PASS: TestGetNeighbors (0.00s)
=== RUN   TestNeighbourLookupAt
--- PASS: TestNeighbourLookupAt (0.00s)
=== RUN   TestNeighbourLookup
--- PASS: TestNeighbourLookup (0.00s)
=== RUN   TestNeighborFilter
--- PASS: TestNeighborFilter (0.00s)
=== RUN   TestRoutesStoreStats
--- PASS: TestRoutesStoreStats (0.01s)
=== RUN   TestLookupPrefixAt
--- PASS: TestLookupPrefixAt (0.01s)
=== RUN   TestLookupPrefix
--- PASS: TestLookupPrefix (0.01s)
=== RUN   TestLookupNeighboursPrefixesAt
--- PASS: TestLookupNeighboursPrefixesAt (0.01s)
=== RUN   TestLookupPrefixForNeighbours
--- PASS: TestLookupPrefixForNeighbours (0.01s)
=== RUN   TestThemeFiles
--- PASS: TestThemeFiles (0.00s)
=== RUN   TestThemeIncludeHash
    theme_test.go:77: Filehash: 607f546f
--- PASS: TestThemeIncludeHash (0.00s)
=== RUN   TestThemeIncludes
--- PASS: TestThemeIncludes (0.00s)
=== RUN   TestContainsCi
--- PASS: TestContainsCi (0.00s)
=== RUN   TestMaybePrefix
--- PASS: TestMaybePrefix (0.00s)
=== RUN   TestTrimmedStringList
--- PASS: TestTrimmedStringList (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/pkg/backend	(cached)
=== RUN   TestLRUMap
--- PASS: TestLRUMap (0.00s)
=== RUN   TestNeighborsCacheSetGet
--- PASS: TestNeighborsCacheSetGet (0.03s)
=== RUN   TestRoutesCacheSetGet
--- PASS: TestRoutesCacheSetGet (0.04s)
=== RUN   TestRoutesCacheLru
--- PASS: TestRoutesCacheLru (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/pkg/caches	(cached)
?   	github.com/alice-lg/alice-lg/pkg/sources	[no test files]
=== RUN   Test_ParseApiStatus
--- PASS: Test_ParseApiStatus (0.00s)
=== RUN   Test_NeighboursParsing
--- PASS: Test_NeighboursParsing (0.00s)
=== RUN   Test_RoutesParsing
--- PASS: Test_RoutesParsing (0.00s)
=== RUN   Test_ParseServerTime
--- PASS: Test_ParseServerTime (0.00s)
=== RUN   TestGetMasterPipeName
--- PASS: TestGetMasterPipeName (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/pkg/sources/birdwatcher	(cached)
?   	github.com/alice-lg/alice-lg/pkg/sources/gobgp	[no test files]
=== RUN   Test_OriginAttribute
--- PASS: Test_OriginAttribute (0.00s)
=== RUN   Test_AsPathAttribute
--- PASS: Test_AsPathAttribute (0.00s)
=== RUN   Test_NextHopAttribute
--- PASS: Test_NextHopAttribute (0.00s)
=== RUN   Test_MultiExitDiscAttribute
--- PASS: Test_MultiExitDiscAttribute (0.00s)
=== RUN   Test_LocalPrefAttribute
--- PASS: Test_LocalPrefAttribute (0.00s)
=== RUN   Test_AtomicAggregateAttribute
--- PASS: Test_AtomicAggregateAttribute (0.00s)
=== RUN   Test_AggregatorAttribute
--- PASS: Test_AggregatorAttribute (0.00s)
=== RUN   Test_CommunitiesAttribute
--- PASS: Test_CommunitiesAttribute (0.00s)
=== RUN   Test_OriginatorIdAttribute
--- PASS: Test_OriginatorIdAttribute (0.00s)
=== RUN   Test_ClusterListAttribute
--- PASS: Test_ClusterListAttribute (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_UC
--- PASS: Test_MpReachNLRIAttribute_IPv4_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_UC
--- PASS: Test_MpReachNLRIAttribute_IPv6_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_MPLS
--- PASS: Test_MpReachNLRIAttribute_IPv4_MPLS (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_MPLS
--- PASS: Test_MpReachNLRIAttribute_IPv6_MPLS (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_ENCAP
--- PASS: Test_MpReachNLRIAttribute_IPv4_ENCAP (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_ENCAP
--- PASS: Test_MpReachNLRIAttribute_IPv6_ENCAP (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_AD_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_AD_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_MAC_IP_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_MAC_IP_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_MC_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_MC_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_ES_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_ES_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_EVPN_Prefix_Route
--- PASS: Test_MpReachNLRIAttribute_EVPN_Prefix_Route (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv4_VPN
--- PASS: Test_MpReachNLRIAttribute_IPv4_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_IPv6_VPN
--- PASS: Test_MpReachNLRIAttribute_IPv6_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_RTC_UC
--- PASS: Test_MpReachNLRIAttribute_RTC_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv4_UC
--- PASS: Test_MpReachNLRIAttribute_FS_IPv4_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv4_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_IPv4_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv6_UC
--- PASS: Test_MpReachNLRIAttribute_FS_IPv6_UC (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_IPv6_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_IPv6_VPN (0.00s)
=== RUN   Test_MpReachNLRIAttribute_FS_L2_VPN
--- PASS: Test_MpReachNLRIAttribute_FS_L2_VPN (0.00s)
=== RUN   Test_MpUnreachNLRIAttribute_IPv4_UC
--- PASS: Test_MpUnreachNLRIAttribute_IPv4_UC (0.00s)
=== RUN   Test_ExtendedCommunitiesAttribute
--- PASS: Test_ExtendedCommunitiesAttribute (0.00s)
=== RUN   Test_As4PathAttribute
--- PASS: Test_As4PathAttribute (0.00s)
=== RUN   Test_As4AggregatorAttribute
--- PASS: Test_As4AggregatorAttribute (0.00s)
=== RUN   Test_PmsiTunnelAttribute
--- PASS: Test_PmsiTunnelAttribute (0.00s)
=== RUN   Test_TunnelEncapAttribute
--- PASS: Test_TunnelEncapAttribute (0.00s)
=== RUN   Test_IP6ExtendedCommunitiesAttribute
--- PASS: Test_IP6ExtendedCommunitiesAttribute (0.00s)
=== RUN   Test_AigpAttribute
--- PASS: Test_AigpAttribute (0.00s)
=== RUN   Test_LargeCommunitiesAttribute
--- PASS: Test_LargeCommunitiesAttribute (0.00s)
=== RUN   Test_UnknownAttribute
--- PASS: Test_UnknownAttribute (0.00s)
=== RUN   Test_MultiProtocolCapability
--- PASS: Test_MultiProtocolCapability (0.00s)
=== RUN   Test_RouteRefreshCapability
--- PASS: Test_RouteRefreshCapability (0.00s)
=== RUN   Test_CarryingLabelInfoCapability
--- PASS: Test_CarryingLabelInfoCapability (0.00s)
=== RUN   Test_ExtendedNexthopCapability
--- PASS: Test_ExtendedNexthopCapability (0.00s)
=== RUN   Test_GracefulRestartCapability
--- PASS: Test_GracefulRestartCapability (0.00s)
=== RUN   Test_FourOctetASNumberCapability
--- PASS: Test_FourOctetASNumberCapability (0.00s)
=== RUN   Test_AddPathCapability
--- PASS: Test_AddPathCapability (0.00s)
=== RUN   Test_EnhancedRouteRefreshCapability
--- PASS: Test_EnhancedRouteRefreshCapability (0.00s)
=== RUN   Test_LongLivedGracefulRestartCapability
--- PASS: Test_LongLivedGracefulRestartCapability (0.00s)
=== RUN   Test_RouteRefreshCiscoCapability
--- PASS: Test_RouteRefreshCiscoCapability (0.00s)
=== RUN   Test_UnknownCapability
--- PASS: Test_UnknownCapability (0.00s)
PASS
ok  	github.com/alice-lg/alice-lg/pkg/sources/gobgp/apiutil	(cached)
```