### PR TITLE
Add lg.ix.br (IX.br) to the list of production examples of Alice-LG

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Take a look at Alice-LG production examples at:
 - https://lg.megaport.com/
 - https://lg.netnod.se/
 - https://alice-rs.linx.net/
+- https://lg.ix.br/
 
 And checkout the API at:
 - https://lg.de-cix.net/api/v1/config


### PR DESCRIPTION
Add https://lg.ix.br/ (IX.br) to the list of production examples of Alice-LG