### PR TITLE
Fixes the spinny wheel when searching for a filtered prefix that does…

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,7 +35,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-$(git rev-parse --short HEAD)-$(date +%s)
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,5 +47,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}, ${{ steps.set_tag.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}, ${{ env.REGISTRY }}/${{env.IMAGE_NAME}}:${{ steps.set_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,12 +35,17 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-$(git rev-parse --short HEAD)-$(date +%s)
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Generate branch tag
+        id: set_tag
+        run: |
+          echo "::set-output name=tag::${{ github.ref_name }}-$(git rev-parse --short HEAD)-$(date +%s)"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}, ${{ steps.set_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ WORKDIR /src/alice-lg/cmd/alice-lg
 RUN make alpine
 
 FROM alpine:latest
+
+RUN apk add -U tzdata
+
 COPY --from=backend /src/alice-lg/cmd/alice-lg/alice-lg-linux-amd64 /usr/bin/alice-lg
 RUN ls -lsha /usr/bin/alice-lg
 

--- a/client/components/routeservers/routes/route/column.jsx
+++ b/client/components/routeservers/routes/route/column.jsx
@@ -53,7 +53,11 @@ export const ColNetwork = function(props) {
 
 // Special AS Path Widget
 export const ColAsPath = function(props) {
-    const asns = _lookup(props.route, "bgp.as_path");
+    let asns = _lookup(props.route, "bgp.as_path");
+    if(!asns){
+      asns = [];
+    }
+
     const baseUrl = "https://irrexplorer.nlnog.net/asn/AS"
 
     let asnLinks = asns.map((asn, i) => {


### PR DESCRIPTION
Hey @annikahannig 

The first PR to fix a problem.

Searching for a prefix that is filtered throws a javascript issue. This resolves that. Example of issue: https://lg.ix.asn.au/search/?q=103.10.125.0/24 Note in the JS console it errors out, but the data does come back from the API call.

ARouteServer (which we use heavily) doesn't keep AS paths for dropped routes, and the loopkup function returns a non-mappable default.

This is fixed on my new image here: https://ixau.alicelg.production.internet.asn.au/search?q=103.10.125.0/24 for reference.