### PR TITLE
Fix an issue that prevented my build to even start.

### DIFF
--- a/client/assets.go
+++ b/client/assets.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Assets hold the alice-lg frontend build
-//go:embed build/*
+// go:embed build/*
 var Assets embed.FS
 
 // AssetsHTTPHandler handles HTTP request at a specific prefix.


### PR DESCRIPTION
I am not a go expert at all, so I don't know the full extent of this
change, but it seems that it unbroke (part of) my build.

It would generate this kind of error:

```
16:56 root@looking-glass /root/go/src/github.com/alice-lg/alice-lg> gmake
go test ./pkg/...
client/assets.go:11:12: pattern build/*: no matching files found
gmake: *** [Makefile:45: backend_tests] Error 1
```
This is on FreeBSD, thus the use of gmake.