### PR TITLE
Update neighbor spelling

### DIFF
--- a/etc/alice-lg/alice.example.conf
+++ b/etc/alice-lg/alice.example.conf
@@ -116,7 +116,7 @@ invalid     = 23042:1000:4-*
 0:* = do not redistribute to AS$1
 
 #
-# Define columns for neighbours and routes table,
+# Define columns for neighbors and routes table,
 # with <key> = <Table Header>
 #
 # and <key> := <object.path> Implicitly referencing the object,
@@ -124,19 +124,19 @@ invalid     = 23042:1000:4-*
 #           |= <Widget>      A widget with special rendering features,
 #                            to which the object is applied. E.g.
 #                            Uptime, which will be rendered as
-#                            Uptime(neighbour).
+#                            Uptime(neighbor).
 #
 # As per convention: Widgets are in Uppercase, object properties are
 # in lowercase.
 #
-# Available Widgets for Neighbours:
+# Available Widgets for Neighbors:
 #
-# Uptime        Displays the relative uptime of this neighbour
-# Description   The neighbour's description with link to routes page
+# Uptime        Displays the relative uptime of this neighbor
+# Description   The neighbor's description with link to routes page
 #
 
-[neighbours_columns]
-address = Neighbour
+[neighbors_columns]
+address = Neighbor
 asn = ASN
 state = State
 Uptime = Uptime
@@ -159,8 +159,8 @@ bgp.as_path = AS Path
 flags = 
 network = Network
 gateway = Gateway
-neighbour.asn = ASN
-neighbour.description = Description
+neighbor.asn = ASN
+neighbor.description = Description
 bgp.as_path = AS Path
 routeserver.name = RS
 

--- a/pkg/sources/birdwatcher/source_multitable.go
+++ b/pkg/sources/birdwatcher/source_multitable.go
@@ -534,18 +534,18 @@ func (src *MultiTableBirdwatcher) NeighborsSummary(
 // from the birdwatcher backend.
 func (src *MultiTableBirdwatcher) Routes(
 	ctx context.Context,
-	neighbourID string,
+	neighborID string,
 ) (*api.RoutesResponse, error) {
 	response := &api.RoutesResponse{}
 	// Fetch required routes first (received and filtered)
 	// However: Store in separate cache for faster access
-	required, err := src.fetchRequiredRoutes(ctx, neighbourID)
+	required, err := src.fetchRequiredRoutes(ctx, neighborID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Optional: NoExport
-	_, notExported, err := src.fetchNotExportedRoutes(ctx, neighbourID)
+	_, notExported, err := src.fetchNotExportedRoutes(ctx, neighborID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There are still a few places that neighbor is spelled as "neighbour".

For people using the example configuration, this misspelling is a bit of a problem as it breaks the search page.

This change just cleans up a few remaining spelling differences