### PR TITLE
OpenBGPD: Restore Neighbor IDs

### DIFF
--- a/pkg/sources/openbgpd/decoders.go
+++ b/pkg/sources/openbgpd/decoders.go
@@ -43,7 +43,7 @@ func decodeNeighbor(n interface{}) (*api.Neighbor, error) {
 	prefixes := decoders.MapGet(stats, "prefixes", map[string]interface{}{})
 
 	neighbor := &api.Neighbor{
-		// ID:             decoders.MapGetString(nb, "remote_addr", "invalid_id"),
+		ID:             decoders.MapGetString(nb, "remote_addr", "invalid_id"),
 		Address:        decoders.MapGetString(nb, "remote_addr", "invalid_address"),
 		ASN:            decoders.IntFromString(decoders.MapGetString(nb, "remote_as", ""), -1),
 		State:          decodeState(decoders.MapGetString(nb, "state", "unknown")),


### PR DESCRIPTION
This fixes the regression introduced with 6.1.0 for OpenBGPD / bgplgd source types.

Fixes alice-lg/alice-lg#135