### PR TITLE
Add support for per-Source Hidden Neighbors

### DIFF
--- a/etc/alice-lg/alice.example.conf
+++ b/etc/alice-lg/alice.example.conf
@@ -213,6 +213,8 @@ name = rs1.example.com (IPv4)
 # Optional: a group for the routeservers list
 group = FRA
 blackholes = 10.23.6.666, 10.23.6.665
+# Optional: hidden_neighbors can list strings of IPs, CIDRs, or Regexes to filter from being shown
+hidden_neighbors = 10.0.0.0/8, 192.168.0.0/16, AS64496_.*
 
 [source.rs0-example-v4.birdwatcher]
 api = http://rs1.example.com:29184/

--- a/pkg/api/response_neighbors.go
+++ b/pkg/api/response_neighbors.go
@@ -55,7 +55,7 @@ func (neighbors Neighbors) Swap(i, j int) {
 	neighbors[i], neighbors[j] = neighbors[j], neighbors[i]
 }
 
-// MatchSourceID implements Filterable interface
+// MatchSourceID implements RouteFilterable interface
 func (n *Neighbor) MatchSourceID(id string) bool {
 	return n.RouteServerID == id
 }
@@ -87,6 +87,12 @@ func (n *Neighbor) MatchName(name string) bool {
 	neighName := strings.ToLower(n.Description)
 
 	return strings.Contains(neighName, name)
+}
+
+// NeighborAddress implements NeighborFilterable and returns the
+// neighbor's address used for hidden neighbor matching.
+func (n *Neighbor) NeighborAddress() string {
+	return n.Address
 }
 
 // RoutesChannel has the routes stats per channel,
@@ -123,6 +129,25 @@ type NeighborStatus struct {
 	ID    string        `json:"id"`
 	State string        `json:"state"`
 	Since time.Duration `json:"uptime"`
+}
+
+// MatchName implements NeighborFilterable. A neighbor status carries
+// no description, so it never matches a name.
+func (n *NeighborStatus) MatchName(string) bool {
+	return false
+}
+
+// MatchASN implements NeighborFilterable. A neighbor status carries
+// no ASN, so it never matches an ASN.
+func (n *NeighborStatus) MatchASN(int) bool {
+	return false
+}
+
+// NeighborAddress implements NeighborFilterable and returns the
+// neighbor's protocol ID used for hidden neighbor matching. This may
+// be an IP address or a protocol name, depending on the backend.
+func (n *NeighborStatus) NeighborAddress() string {
+	return n.ID
 }
 
 // NeighborsStatus is a list of statuses.

--- a/pkg/api/response_routes.go
+++ b/pkg/api/response_routes.go
@@ -40,7 +40,7 @@ func (r *Route) MatchAddrFamily(family uint8) bool {
 	return r.AddrFamily == family
 }
 
-// MatchSourceID implements Filterable interface for routes
+// MatchSourceID implements RouteFilterable interface for routes
 func (r *Route) MatchSourceID(id string) bool {
 	return true // A route has no source info so we exclude this filter
 }

--- a/pkg/api/search_filters.go
+++ b/pkg/api/search_filters.go
@@ -3,7 +3,9 @@ package api
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -18,9 +20,9 @@ const (
 	SearchKeyAddrFamily       = "addr_family"
 )
 
-// Filterable objects provide methods for matching
+// RouteFilterable objects provide methods for matching
 // by ID, ASN, Community, etc...
-type Filterable interface {
+type RouteFilterable interface {
 	MatchSourceID(sourceID string) bool
 	MatchASN(asn int) bool
 	MatchCommunity(community Community) bool
@@ -227,9 +229,9 @@ func (g *SearchFilterGroup) rebuildIndex() {
 }
 
 // A SearchFilterComparator compares route with a filter
-type SearchFilterComparator func(route Filterable, value any) bool
+type SearchFilterComparator func(route RouteFilterable, value any) bool
 
-func searchFilterMatchSource(route Filterable, value any) bool {
+func searchFilterMatchSource(route RouteFilterable, value any) bool {
 	sourceID, ok := value.(string)
 	if !ok {
 		return false
@@ -237,7 +239,7 @@ func searchFilterMatchSource(route Filterable, value any) bool {
 	return route.MatchSourceID(sourceID)
 }
 
-func searchFilterMatchASN(route Filterable, value any) bool {
+func searchFilterMatchASN(route RouteFilterable, value any) bool {
 	asn, ok := value.(int)
 	if !ok {
 		return false
@@ -246,7 +248,7 @@ func searchFilterMatchASN(route Filterable, value any) bool {
 	return route.MatchASN(asn)
 }
 
-func searchFilterMatchCommunity(route Filterable, value any) bool {
+func searchFilterMatchCommunity(route RouteFilterable, value any) bool {
 	community, ok := value.(Community)
 	if !ok {
 		return false
@@ -254,7 +256,7 @@ func searchFilterMatchCommunity(route Filterable, value any) bool {
 	return route.MatchCommunity(community)
 }
 
-func searchFilterMatchExtCommunity(route Filterable, value any) bool {
+func searchFilterMatchExtCommunity(route RouteFilterable, value any) bool {
 	community, ok := value.(ExtCommunity)
 	if !ok {
 		return false
@@ -262,7 +264,7 @@ func searchFilterMatchExtCommunity(route Filterable, value any) bool {
 	return route.MatchExtCommunity(community)
 }
 
-func searchFilterMatchLargeCommunity(route Filterable, value any) bool {
+func searchFilterMatchLargeCommunity(route RouteFilterable, value any) bool {
 	community, ok := value.(Community)
 	if !ok {
 		return false
@@ -270,7 +272,7 @@ func searchFilterMatchLargeCommunity(route Filterable, value any) bool {
 	return route.MatchLargeCommunity(community)
 }
 
-func searchFilterMatchAddrFamily(route Filterable, value any) bool {
+func searchFilterMatchAddrFamily(route RouteFilterable, value any) bool {
 	family, ok := value.(int)
 	if !ok {
 		return false
@@ -302,7 +304,7 @@ func selectCmpFuncByKey(key string) SearchFilterComparator {
 
 // MatchAny checks if a route matches any filter
 // in a filter group.
-func (g *SearchFilterGroup) MatchAny(route Filterable) bool {
+func (g *SearchFilterGroup) MatchAny(route RouteFilterable) bool {
 	// Check if we have any filter to match
 	if len(g.Filters) == 0 {
 		return true // no filter, everything matches
@@ -325,7 +327,7 @@ func (g *SearchFilterGroup) MatchAny(route Filterable) bool {
 
 // MatchAll checks if a route matches all predicates
 // in the filter group.
-func (g *SearchFilterGroup) MatchAll(route Filterable) bool {
+func (g *SearchFilterGroup) MatchAll(route RouteFilterable) bool {
 	// Check if we have any filter to match
 	if len(g.Filters) == 0 {
 		return true // no filter, everything matches. Like above.
@@ -646,7 +648,7 @@ func FiltersFromTokens(tokens []string) (*SearchFilters, error) {
 
 // MatchRoute checks if a route matches all filters.
 // Unless all filters are blank.
-func (s *SearchFilters) MatchRoute(r Filterable) bool {
+func (s *SearchFilters) MatchRoute(r RouteFilterable) bool {
 	sources := s.GetGroupByKey(SearchKeySources)
 	if !sources.MatchAny(r) {
 		return false
@@ -752,12 +754,61 @@ func (s *SearchFilters) HasGroup(key string) bool {
 	return len(group.Filters) > 0
 }
 
-// A NeighborFilter includes only a name and ASN.
-// We are using a slightly simpler solution for
-// neighbor queries.
+// NeighborFilterable objects can be matched against a NeighborFilter.
+// It is implemented by *Neighbor and *NeighborStatus, so the same
+// filter can be applied to both the full neighbor list and the
+// reduced neighbor status list.
+type NeighborFilterable interface {
+	// MatchName reports a (partial, case insensitive) match of the
+	// neighbor's description / name.
+	MatchName(name string) bool
+	// MatchASN reports whether the neighbor has the given ASN.
+	MatchASN(asn int) bool
+	// NeighborAddress returns the address (or protocol ID) used for
+	// address based matching, e.g. hidden neighbor exclusion.
+	NeighborAddress() string
+}
+
+// A NeighborFilter is used both for neighbor queries (by name and
+// ASN) and for excluding hidden neighbors from a source's responses.
+//
+// The exclusion rules (IPs, CIDRs and regular expressions) are parsed
+// once at configuration time so that invalid patterns fail fast.
 type NeighborFilter struct {
 	name string
 	asn  int
+
+	// Hidden neighbor exclusion rules
+	excludeIPs      []net.IP
+	excludeCIDRs    []*net.IPNet
+	excludePatterns []*regexp.Regexp
+}
+
+// NeighborFilterFromPatterns constructs a NeighborFilter from a list
+// of exclusion patterns. Each entry is interpreted, in order, as a
+// CIDR, an IP address, or a regular expression matched against the
+// neighbor address (or protocol ID).
+//
+// A compilation error is returned for invalid regular expressions so
+// that broken configuration is rejected at parse time instead of on
+// the first refresh or request.
+func NeighborFilterFromPatterns(patterns []string) (*NeighborFilter, error) {
+	filter := &NeighborFilter{}
+	for _, pattern := range patterns {
+		if _, cidr, err := net.ParseCIDR(pattern); err == nil {
+			filter.excludeCIDRs = append(filter.excludeCIDRs, cidr)
+		} else if ip := net.ParseIP(pattern); ip != nil {
+			filter.excludeIPs = append(filter.excludeIPs, ip)
+		} else {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"invalid hidden neighbor pattern %q: %w", pattern, err)
+			}
+			filter.excludePatterns = append(filter.excludePatterns, re)
+		}
+	}
+	return filter, nil
 }
 
 // NeighborFilterFromQuery constructs a NeighborFilter
@@ -793,7 +844,7 @@ func NeighborFilterFromQueryString(q string) *NeighborFilter {
 
 // Match neighbor with filter: Check if the neighbor
 // in question has the required parameters.
-func (s *NeighborFilter) Match(neighbor *Neighbor) bool {
+func (s *NeighborFilter) Match(neighbor NeighborFilterable) bool {
 	if s.name != "" && neighbor.MatchName(s.name) {
 		return true
 	}
@@ -801,4 +852,49 @@ func (s *NeighborFilter) Match(neighbor *Neighbor) bool {
 		return true
 	}
 	return false
+}
+
+// MatchHidden reports whether the neighbor should be hidden according
+// to the filter's IP, CIDR and regular-expression exclusion rules.
+func (s *NeighborFilter) MatchHidden(neighbor NeighborFilterable) bool {
+	address := neighbor.NeighborAddress()
+	if ip := net.ParseIP(address); ip != nil {
+		for _, excluded := range s.excludeIPs {
+			if ip.Equal(excluded) {
+				return true
+			}
+		}
+		for _, cidr := range s.excludeCIDRs {
+			if cidr.Contains(ip) {
+				return true
+			}
+		}
+	}
+	for _, pattern := range s.excludePatterns {
+		if pattern.MatchString(address) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExcludeHidden returns the subset of neighbors that are not hidden by
+// the given filter. It is generic over the neighbor type so it can be
+// applied to both api.Neighbors and api.NeighborsStatus. A nil filter
+// leaves the input unchanged.
+func ExcludeHidden[T NeighborFilterable](
+	filter *NeighborFilter,
+	neighbors []T,
+) []T {
+	if filter == nil {
+		return neighbors
+	}
+	visible := make([]T, 0, len(neighbors))
+	for _, neighbor := range neighbors {
+		if filter.MatchHidden(neighbor) {
+			continue
+		}
+		visible = append(visible, neighbor)
+	}
+	return visible
 }

--- a/pkg/api/search_filters_test.go
+++ b/pkg/api/search_filters_test.go
@@ -359,7 +359,7 @@ func TestSearchFilterExcludeRoute(t *testing.T) {
 }
 
 // Communities should match all aswell
-func testSearchFilterCommunities(route Filterable, t *testing.T) {
+func testSearchFilterCommunities(route RouteFilterable, t *testing.T) {
 	query := "communities=23:42,111:11"
 	values, err := url.ParseQuery(query)
 	if err != nil {
@@ -402,7 +402,7 @@ func TestSearchFilterLookupRouteCommunity(t *testing.T) {
 }
 
 // Check that ext. communities work
-func testSearchFilterExtCommunities(route Filterable, t *testing.T) {
+func testSearchFilterExtCommunities(route RouteFilterable, t *testing.T) {
 	query := "ext_communities=ro:23:123"
 	values, err := url.ParseQuery(query)
 	if err != nil {
@@ -450,7 +450,7 @@ func TestSearchFilterLookupRouteExtCommunities(t *testing.T) {
 }
 
 // Check that large communities work aswell
-func testSearchFilterLargeCommunities(route Filterable, t *testing.T) {
+func testSearchFilterLargeCommunities(route RouteFilterable, t *testing.T) {
 	query := "large_communities=1000:23:42"
 	values, err := url.ParseQuery(query)
 	if err != nil {
@@ -638,6 +638,87 @@ func TestNeighborFilterMatch(t *testing.T) {
 
 	if filter.Match(n1) == false || filter.Match(n2) == false {
 		t.Error("Expected filter to match both neighbors.")
+	}
+}
+
+func TestNeighborFilterFromPatternsInvalid(t *testing.T) {
+	// An unparseable regular expression (that is neither a valid
+	// CIDR nor IP) must be rejected at construction time.
+	if _, err := NeighborFilterFromPatterns([]string{"*invalid("}); err == nil {
+		t.Error("Expected an error for an invalid pattern")
+	}
+}
+
+func TestNeighborFilterMatchHidden(t *testing.T) {
+	filter, err := NeighborFilterFromPatterns([]string{
+		"192.0.2.1",         // single IP
+		"2001:db8::/32",     // CIDR
+		"^rs-.*-collector$", // regexp on protocol name
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		address string
+		hidden  bool
+	}{
+		{"192.0.2.1", true},         // exact IP
+		{"192.0.2.2", false},        // different IP
+		{"2001:db8:1234::5", true},  // inside CIDR
+		{"2001:dead::1", false},     // outside CIDR
+		{"rs-flow-collector", true}, // matches regexp
+		{"rs-normal-peer", false},   // does not match regexp
+		{"192_0_2_1", false},        // non-IP, non-matching string
+	}
+
+	for _, c := range cases {
+		n := &Neighbor{Address: c.address}
+		if got := filter.MatchHidden(n); got != c.hidden {
+			t.Errorf("MatchHidden(%q) = %v, want %v", c.address, got, c.hidden)
+		}
+		// NeighborStatus is matched on its ID, which mirrors the
+		// address for the purposes of hidden neighbor exclusion.
+		ns := &NeighborStatus{ID: c.address}
+		if got := filter.MatchHidden(ns); got != c.hidden {
+			t.Errorf("MatchHidden(status %q) = %v, want %v", c.address, got, c.hidden)
+		}
+	}
+}
+
+func TestExcludeHidden(t *testing.T) {
+	filter, err := NeighborFilterFromPatterns([]string{"192.0.2.0/24"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	neighbors := Neighbors{
+		{Address: "192.0.2.10"}, // hidden
+		{Address: "198.51.100.1"},
+		{Address: "192.0.2.20"}, // hidden
+		{Address: "203.0.113.7"},
+	}
+	visible := ExcludeHidden(filter, neighbors)
+	if len(visible) != 2 {
+		t.Fatalf("Expected 2 visible neighbors, got %d", len(visible))
+	}
+	for _, n := range visible {
+		if filter.MatchHidden(n) {
+			t.Errorf("Neighbor %q should have been excluded", n.Address)
+		}
+	}
+
+	// A nil filter leaves the input untouched.
+	if got := ExcludeHidden[*Neighbor](nil, neighbors); len(got) != len(neighbors) {
+		t.Errorf("Expected nil filter to keep all %d neighbors, got %d",
+			len(neighbors), len(got))
+	}
+
+	// An empty filter (no patterns) hides nothing.
+	empty, _ := NeighborFilterFromPatterns(nil)
+	if got := ExcludeHidden(empty, neighbors); len(got) != len(neighbors) {
+		t.Errorf("Expected empty filter to keep all %d neighbors, got %d",
+			len(neighbors), len(got))
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -193,6 +193,10 @@ type SourceConfig struct {
 	// Blackhole IPs
 	Blackholes []string
 
+	// HiddenNeighbors holds the parsed exclusion rules for
+	// neighbors that should not be exposed by this source.
+	HiddenNeighbors *api.NeighborFilter
+
 	// Source configurations
 	Type        string
 	Backend     string
@@ -740,15 +744,23 @@ func getSources(config *ini.File) ([]*SourceConfig, error) {
 		sourceGroup := section.Key("group").MustString("")
 		sourceBlackholes := decoders.TrimmedCSVStringList(
 			section.Key("blackholes").MustString(""))
+		sourceHiddenNeighbors := decoders.TrimmedCSVStringList(
+			section.Key("hidden_neighbors").MustString(""))
+		hiddenNeighbors, err := api.NeighborFilterFromPatterns(sourceHiddenNeighbors)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"in source %s: %w", sourceID, err)
+		}
 
 		srcCfg := &SourceConfig{
-			ID:         sourceID,
-			Order:      order,
-			Name:       sourceName,
-			Group:      sourceGroup,
-			Blackholes: sourceBlackholes,
-			Backend:    backendType,
-			Type:       sourceType,
+			ID:              sourceID,
+			Order:           order,
+			Name:            sourceName,
+			Group:           sourceGroup,
+			Blackholes:      sourceBlackholes,
+			HiddenNeighbors: hiddenNeighbors,
+			Backend:         backendType,
+			Type:            sourceType,
 		}
 
 		// Register route server ID with pool
@@ -772,8 +784,9 @@ func getSources(config *ini.File) ([]*SourceConfig, error) {
 			}
 
 			c := birdwatcher.Config{
-				ID:   srcCfg.ID,
-				Name: srcCfg.Name,
+				ID:              srcCfg.ID,
+				Name:            srcCfg.Name,
+				HiddenNeighbors: srcCfg.HiddenNeighbors,
 
 				Timezone:        "UTC",
 				ServerTime:      "2006-01-02T15:04:05.999999999Z07:00",
@@ -805,8 +818,9 @@ func getSources(config *ini.File) ([]*SourceConfig, error) {
 
 		case SourceBackendGoBGP:
 			c := gobgp.Config{
-				ID:   srcCfg.ID,
-				Name: srcCfg.Name,
+				ID:              srcCfg.ID,
+				Name:            srcCfg.Name,
+				HiddenNeighbors: srcCfg.HiddenNeighbors,
 			}
 
 			if err := backendConfig.MapTo(&c); err != nil {
@@ -833,6 +847,7 @@ func getSources(config *ini.File) ([]*SourceConfig, error) {
 			c := openbgpd.Config{
 				ID:                srcCfg.ID,
 				Name:              srcCfg.Name,
+				HiddenNeighbors:   srcCfg.HiddenNeighbors,
 				CacheTTL:          cacheTTL,
 				RoutesCacheSize:   routesCacheSize,
 				RejectCommunities: rejectComms,
@@ -855,6 +870,7 @@ func getSources(config *ini.File) ([]*SourceConfig, error) {
 			c := openbgpd.Config{
 				ID:                srcCfg.ID,
 				Name:              srcCfg.Name,
+				HiddenNeighbors:   srcCfg.HiddenNeighbors,
 				CacheTTL:          cacheTTL,
 				RoutesCacheSize:   routesCacheSize,
 				RejectCommunities: rejectComms,

--- a/pkg/sources/birdwatcher/config.go
+++ b/pkg/sources/birdwatcher/config.go
@@ -1,10 +1,13 @@
 package birdwatcher
 
+import "github.com/alice-lg/alice-lg/pkg/api"
+
 // Config contains all configuration attributes
 // for a birdwatcher based source.
 type Config struct {
-	ID   string
-	Name string
+	ID              string
+	Name            string
+	HiddenNeighbors *api.NeighborFilter `ini:"-"`
 
 	API             string `ini:"api"`
 	Timezone        string `ini:"timezone"`

--- a/pkg/sources/birdwatcher/source.go
+++ b/pkg/sources/birdwatcher/source.go
@@ -257,6 +257,7 @@ func (b *GenericBirdwatcher) NeighborsStatus(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
+	neighbors = api.ExcludeHidden(b.config.HiddenNeighbors, neighbors)
 
 	response := &api.NeighborsStatusResponse{
 		Response: api.Response{

--- a/pkg/sources/birdwatcher/source_multitable.go
+++ b/pkg/sources/birdwatcher/source_multitable.go
@@ -644,6 +644,9 @@ func (src *MultiTableBirdwatcher) Neighbors(
 		response = res
 	}
 
+	response.Neighbors = api.ExcludeHidden(
+		src.config.HiddenNeighbors, response.Neighbors)
+
 	// Cache result
 	src.neighborsCache.Set(response)
 

--- a/pkg/sources/birdwatcher/source_singletable.go
+++ b/pkg/sources/birdwatcher/source_singletable.go
@@ -159,6 +159,8 @@ func (src *SingleTableBirdwatcher) Neighbors(
 		return nil, err
 	}
 
+	neighbors = api.ExcludeHidden(src.config.HiddenNeighbors, neighbors)
+
 	response = &api.NeighborsResponse{
 		Response: api.Response{
 			Meta: apiStatus,

--- a/pkg/sources/gobgp/config.go
+++ b/pkg/sources/gobgp/config.go
@@ -1,9 +1,12 @@
 package gobgp
 
+import "github.com/alice-lg/alice-lg/pkg/api"
+
 // Config is a GoBGP source config
 type Config struct {
-	ID   string
-	Name string
+	ID              string
+	Name            string
+	HiddenNeighbors *api.NeighborFilter `ini:"-"`
 
 	Host     string `ini:"host"`
 	Insecure bool   `ini:"insecure"`

--- a/pkg/sources/gobgp/source.go
+++ b/pkg/sources/gobgp/source.go
@@ -133,6 +133,8 @@ func (gobgp *GoBGP) NeighborsStatus(
 		response.Neighbors = append(response.Neighbors, &ns)
 
 	}
+	response.Neighbors = api.ExcludeHidden(
+		gobgp.config.HiddenNeighbors, response.Neighbors)
 	return &response, nil
 }
 
@@ -212,6 +214,9 @@ func (gobgp *GoBGP) Neighbors(
 		}
 
 	}
+
+	response.Neighbors = api.ExcludeHidden(
+		gobgp.config.HiddenNeighbors, response.Neighbors)
 
 	return &response, nil
 }

--- a/pkg/sources/openbgpd/bgplgd_source.go
+++ b/pkg/sources/openbgpd/bgplgd_source.go
@@ -154,6 +154,7 @@ func (src *BgplgdSource) Neighbors(
 	if err != nil {
 		return nil, err
 	}
+	nb = api.ExcludeHidden(src.cfg.HiddenNeighbors, nb)
 	// Set route server id (sourceID) for all neighbors and
 	// calculate the filtered routes.
 	for _, n := range nb {
@@ -207,6 +208,8 @@ func (src *BgplgdSource) NeighborsSummary(
 	if err != nil {
 		return nil, err
 	}
+	nb = api.ExcludeHidden(src.cfg.HiddenNeighbors, nb)
+
 	// Set route server id (sourceID) for all neighbors and
 	// calculate the filtered routes.
 	for _, n := range nb {
@@ -248,6 +251,7 @@ func (src *BgplgdSource) NeighborsStatus(
 	if err != nil {
 		return nil, err
 	}
+	nb = api.ExcludeHidden(src.cfg.HiddenNeighbors, nb)
 
 	response := &api.NeighborsStatusResponse{
 		Response: api.Response{

--- a/pkg/sources/openbgpd/config.go
+++ b/pkg/sources/openbgpd/config.go
@@ -10,8 +10,9 @@ import (
 
 // Config is a OpenBGPD source config
 type Config struct {
-	ID   string
-	Name string
+	ID              string
+	Name            string
+	HiddenNeighbors *api.NeighborFilter `ini:"-"`
 
 	CacheTTL        time.Duration
 	RoutesCacheSize int

--- a/pkg/sources/openbgpd/state_server_source.go
+++ b/pkg/sources/openbgpd/state_server_source.go
@@ -196,6 +196,8 @@ func (src *StateServerSource) Neighbors(
 		},
 		Neighbors: nb,
 	}
+	response.Neighbors = api.ExcludeHidden(
+		src.cfg.HiddenNeighbors, response.Neighbors)
 	src.neighborsCache.Set(response)
 
 	return response, nil
@@ -231,6 +233,7 @@ func (src *StateServerSource) NeighborsSummary(
 	if err != nil {
 		return nil, err
 	}
+	nb = api.ExcludeHidden(src.cfg.HiddenNeighbors, nb)
 	// Set route server id (sourceID) for all neighbors
 	for _, n := range nb {
 		n.RouteServerID = src.cfg.ID
@@ -271,6 +274,7 @@ func (src *StateServerSource) NeighborsStatus(
 	if err != nil {
 		return nil, err
 	}
+	nb = api.ExcludeHidden(src.cfg.HiddenNeighbors, nb)
 
 	response := &api.NeighborsStatusResponse{
 		Response: api.Response{

--- a/pkg/sources/source.go
+++ b/pkg/sources/source.go
@@ -21,7 +21,7 @@ var (
 )
 
 // Source is a generic datasource for alice.
-// All route server adapters implement this interface.
+// All route server Source adapters implement this interface.
 type Source interface {
 	ExpireCaches() int
 


### PR DESCRIPTION
Closes #142 

As part of Route Server operations, it is sometimes necessary to configure some BGP Neighbors which are not appropriate for a public Looking Glass interface.
For example, an internal route server peer used to collect routes for flow analytics, but which is not a "normal" Route Server peer. Another example: an internal (route server)-to-(route server) peer used to scale a multi-instance route server.

This PR adds some support to Alice to enable configuring some Neighbors to be hidden on a per-source basis. This filtration could be based on IPs, CIDRs, or Regular Expressions. As BIRD(watcher) has some some NeighborStatus IDs which are potentially not IP addresses, it seemed important to enable filtering either IPs or Neighbor Protocol names.