### PR TITLE
GoBGP: Construct NeighborsStatus response

### DIFF
--- a/pkg/sources/gobgp/source.go
+++ b/pkg/sources/gobgp/source.go
@@ -130,6 +130,7 @@ func (gobgp *GoBGP) NeighborsStatus(
 				_resp.Peer.Timers.State.Uptime.Seconds,
 				int64(_resp.Peer.Timers.State.Uptime.Nanos)))
 		}
+		response.Neighbors = append(response.Neighbors, &ns)
 
 	}
 	return &response, nil


### PR DESCRIPTION
While working on #142 / #143, I noticed that the GoBGP source didn't seem to construct NeighborsStatus correctly, so adding this slice appending to make it correct.