### PR TITLE
alice.conf: Add some comments about section usage

### DIFF
--- a/etc/alice-lg/alice.example.conf
+++ b/etc/alice-lg/alice.example.conf
@@ -83,8 +83,10 @@ routes_accepted_page_size = 250
 routes_not_exported_page_size = 250
 
 [rejection_reasons]
-# a pair of a large BGP community value and a string to signal the processing
-# results of route filtering
+# BGP communities which, when present on a prefix represent the route as having
+# been filtered out.
+# Additionally, communities for searching and descriptions should be listed in
+# the [bgp_communities] section of this configuration.
 9033:65666:1 = An IP Bogon was detected
 9033:65666:2 = Prefix is longer than 64
 9033:65666:3 = Prefix is longer than 24
@@ -140,7 +142,8 @@ unknown     = 23042:1000:2
 invalid     = 23042:1000:4-*
 
 
-# Define other known bgp communities
+# Define known bgp communities which should be recognized and described in the
+# Alice web UI
 [bgp_communities]
 1:23 = some tag
 9033:65666:1 = ip bogon detected


### PR DESCRIPTION
I was duplicating a lot of prefixes into `[rejection_reasons]`. With the BIRD source, this wasn't an issue, but with bgplgd sources which don't show Adj-RIBs-Out data per-peer, the presence of a route in the `[rejection_reasons]` section actually shows the route as filtered, even though it wasn't actually getting filtered out.

This adds some comments to the sections to describe their use a bit more, in the hopes of preventing this confusion for future alice-lg operators.