### PR TITLE
Use triangle as reject candidate icon

### DIFF
--- a/ui/src/app/components/routes/flags/RejectCandidateIndicator.js
+++ b/ui/src/app/components/routes/flags/RejectCandidateIndicator.js
@@ -1,5 +1,5 @@
 
-import { faCircleExclamation }
+import { faTriangleExclamation }
   from '@fortawesome/free-solid-svg-icons';
 
 import { useRejectCandidate }
@@ -22,7 +22,7 @@ const RejectCandidateIndicator = ({route}) => {
 
   return (
     <span className="route-prefix-flag reject-candidate-route">
-      <FlagIcon icon={faCircleExclamation} tooltip="Reject Candidate" />
+      <FlagIcon icon={faTriangleExclamation} tooltip="Reject Candidate" />
     </span>
   );
 }


### PR DESCRIPTION
This PR changes the circular exclamation mark icon used for reject candidates to a triangular one.