### PR TITLE
chore: bump to go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD ui/ .
 RUN yarn build 
 
 # Build the backend
-FROM golang:1.21 AS backend
+FROM golang:1.24 AS backend
 
 # Install dependencies
 WORKDIR /src/alice-lg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alice-lg/alice-lg
 
-go 1.22.7
+go 1.24
 
 require (
 	github.com/go-ini/ini v1.67.0


### PR DESCRIPTION
Go team only suports the last 2 Go version for updates.  With Go 1.25 being out this means Go 1.24 and Go 1.25 are supported.  Go 1.24 seems like a "safer" bump (but to be honest either would be fine).

This also fixes the Dockerfile from being built where where is a mismatch with go versions.  

```
 => ERROR [backend 5/9] RUN go mod download                                                                                                                                                                      0.1s
------
 > [backend 5/9] RUN go mod download:
0.071 go: go.mod requires go >= 1.22.7 (running go 1.21.13; GOTOOLCHAIN=local)
```