### PR TITLE
Dockerfile fixes due to build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Build frontend first
-FROM node:latest AS ui
+FROM node:24 AS ui
 
 # Install dependencies 
 WORKDIR /src/alice-lg/ui
@@ -36,7 +36,7 @@ COPY --from=ui /src/alice-lg/ui/build ui/build
 WORKDIR /src/alice-lg/cmd/alice-lg
 RUN make alpine
 
-FROM alpine:latest
+FROM alpine:3.22
 
 RUN apk add -U tzdata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,5 @@ RUN apk add -U tzdata
 COPY --from=backend /src/alice-lg/cmd/alice-lg/alice-lg-linux-amd64 /usr/bin/alice-lg
 RUN ls -lsha /usr/bin/alice-lg
 
-EXPOSE 7340:7340
+EXPOSE 7340/tcp
 CMD ["/usr/bin/alice-lg"]


### PR DESCRIPTION
1. The "latest" versions of base images replaced to specific ones because of upstream changing (potential) issues.
2. Fixes incorrect EXPOSE declaration.

I tried to build image from changed Dockerfile - it completes without errors.

Related issue: #184