### PR TITLE
fix: encode neighborId before inserting into birdwatcher URL path (singletable)

### DIFF
--- a/pkg/http/api_endpoints_routes.go
+++ b/pkg/http/api_endpoints_routes.go
@@ -51,7 +51,10 @@ func (s *Server) apiRoutesListReceived(
 		return nil, err
 	}
 
-	neighborID := params.ByName("neighborId")
+	neighborID, err := validateNeighborID(params.ByName("neighborId"))
+	if err != nil {
+		return nil, err
+	}
 	source := s.cfg.SourceInstanceByID(rsID)
 	if source == nil {
 		return nil, ErrSourceNotFound
@@ -133,7 +136,10 @@ func (s *Server) apiRoutesListFiltered(
 		return nil, err
 	}
 
-	neighborID := params.ByName("neighborId")
+	neighborID, err := validateNeighborID(params.ByName("neighborId"))
+	if err != nil {
+		return nil, err
+	}
 	source := s.cfg.SourceInstanceByID(rsID)
 	if source == nil {
 		return nil, ErrSourceNotFound
@@ -216,7 +222,10 @@ func (s *Server) apiRoutesListNotExported(
 		return nil, err
 	}
 
-	neighborID := params.ByName("neighborId")
+	neighborID, err := validateNeighborID(params.ByName("neighborId"))
+	if err != nil {
+		return nil, err
+	}
 	source := s.cfg.SourceInstanceByID(rsID)
 	if source == nil {
 		return nil, ErrSourceNotFound

--- a/pkg/http/api_validators.go
+++ b/pkg/http/api_validators.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"net/http"
@@ -59,6 +60,22 @@ var (
 		"q", "a prefix query must contain at least a '.' or ':'",
 	}
 )
+
+// reValidNeighborID matches BIRD protocol names: alphanumeric and underscore only.
+var reValidNeighborID = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// validateNeighborID rejects neighborId values that contain URL structural
+// characters (e.g. '?', '#', '&') which would otherwise be injected into
+// internal birdwatcher API URLs when concatenated without encoding.
+func validateNeighborID(id string) (string, error) {
+	if !reValidNeighborID.MatchString(id) {
+		return "", &ErrValidationFailed{
+			Param:  "neighborId",
+			Reason: "neighborId contains invalid characters",
+		}
+	}
+	return id, nil
+}
 
 // Helper: Validate source Id
 func validateSourceID(id string) (string, error) {

--- a/pkg/sources/birdwatcher/source_singletable.go
+++ b/pkg/sources/birdwatcher/source_singletable.go
@@ -3,6 +3,7 @@ package birdwatcher
 import (
 	"context"
 	"log"
+	"net/url"
 
 	"github.com/alice-lg/alice-lg/pkg/api"
 )
@@ -16,7 +17,7 @@ func (src *SingleTableBirdwatcher) fetchReceivedRoutes(
 	ctx context.Context,
 	neighborID string,
 ) (*api.Meta, api.Routes, error) {
-	res, err := src.client.GetEndpoint(ctx, "/routes/protocol/"+neighborID)
+	res, err := src.client.GetEndpoint(ctx, "/routes/protocol/"+url.PathEscape(neighborID))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -34,7 +35,7 @@ func (src *SingleTableBirdwatcher) fetchFilteredRoutes(
 	ctx context.Context,
 	neighborID string,
 ) (*api.Meta, api.Routes, error) {
-	res, err := src.client.GetEndpoint(ctx, "/routes/filtered/"+neighborID)
+	res, err := src.client.GetEndpoint(ctx, "/routes/filtered/"+url.PathEscape(neighborID))
 	if err != nil {
 		log.Println("WARNING Could not retrieve filtered routes:", err)
 		log.Println("Is the 'routes_filtered' module active in birdwatcher?")
@@ -54,7 +55,7 @@ func (src *SingleTableBirdwatcher) fetchNotExportedRoutes(
 	ctx context.Context,
 	neighborID string,
 ) (*api.Meta, api.Routes, error) {
-	res, err := src.client.GetEndpoint(ctx, "/routes/noexport/"+neighborID)
+	res, err := src.client.GetEndpoint(ctx, "/routes/noexport/"+url.PathEscape(neighborID))
 	if err != nil {
 		log.Println("WARNING Could not retrieve routes not exported:", err)
 		log.Println("Is the 'routes_noexport' module active in birdwatcher?")


### PR DESCRIPTION
## Summary

In the `SingleTableBirdwatcher` backend, `neighborId` was concatenated directly into internal birdwatcher API URLs without encoding. A URL-encoded `?` (`%3F`) in the `neighborId` path segment is decoded to a literal `?` by httprouter before the handler receives it. When alice-lg then builds the birdwatcher request URL (`/routes/protocol/` + neighborID), the `?` acts as a query separator — injecting attacker-controlled parameters into requests to the internal birdwatcher daemon.

Birdwatcher currently ignores unknown query parameters, limiting today's impact. The material risk is the unguarded injection channel into an internal service: if birdwatcher adds query parameter handling in future, this path becomes exploitable without any change to alice-lg.

Only `SingleTableBirdwatcher` is affected. `MultiTableBirdwatcher` validates `neighborId` against a known protocols map before URL construction and is not affected.

**Affected endpoints:**
- `GET /api/v1/routeservers/:id/neighbors/:neighborId/routes/received`
- `GET /api/v1/routeservers/:id/neighbors/:neighborId/routes/filtered`
- `GET /api/v1/routeservers/:id/neighbors/:neighborId/routes/not-exported`

## Changes

- **`pkg/sources/birdwatcher/source_singletable.go`**: Apply `url.PathEscape()` to `neighborID` at all three `GetEndpoint` concatenation points (`fetchReceivedRoutes`, `fetchFilteredRoutes`, `fetchNotExportedRoutes`). This ensures `?`, `#`, `&`, and other URL structural characters are percent-encoded as literal path characters.

- **`pkg/http/api_validators.go`**: Add `validateNeighborID()` — an allowlist validator using `^[A-Za-z0-9_]+$` matching BIRD protocol name syntax. Returns `ErrValidationFailed` (HTTP 400) for any value containing characters outside that set.

- **`pkg/http/api_endpoints_routes.go`**: Call `validateNeighborID()` in all three route handlers (`apiRoutesListReceived`, `apiRoutesListFiltered`, `apiRoutesListNotExported`) before the `neighborId` value is passed to the source layer.

## Test plan

- [ ] Send a request with a valid `neighborId` (e.g. `AS64496_1`) — should return routes as normal
- [ ] Send a request with `neighborId` containing `%3F` (decoded to `?`) — handler should return HTTP 400
- [ ] Send a request with `neighborId` containing `%26` (`&`) or `%23` (`#`) — handler should return HTTP 400
- [ ] Confirm `MultiTableBirdwatcher` endpoints are unaffected