### PR TITLE
fix: prevent directory listing and dotfile access on theme endpoint

### DIFF
--- a/pkg/http/theme.go
+++ b/pkg/http/theme.go
@@ -127,12 +127,41 @@ func (t *Theme) ScriptIncludes() string {
 	return strings.Join(includes, "\n")
 }
 
+// noDirListFS wraps an http.FileSystem and returns 404 for directory requests
+// and dotfile requests, preventing http.FileServer from generating directory
+// listing HTML pages and serving hidden files. This aligns the HTTP-serving
+// behaviour with listIncludes(), which already excludes both.
+type noDirListFS struct {
+	http.FileSystem
+}
+
+func (fs noDirListFS) Open(name string) (http.File, error) {
+	for _, part := range strings.Split(name, "/") {
+		if strings.HasPrefix(part, ".") && part != "." {
+			return nil, os.ErrNotExist
+		}
+	}
+	f, err := fs.FileSystem.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if stat.IsDir() {
+		f.Close()
+		return nil, os.ErrNotExist
+	}
+	return f, nil
+}
+
 // Handler is the theme HTTP handler
 func (t *Theme) Handler() http.Handler {
-	// Serve the content using the file server
 	path := t.Config.Path
 	themeFilesHandler := http.StripPrefix(
-		t.Config.BasePath, http.FileServer(http.Dir(path)))
+		t.Config.BasePath, http.FileServer(noDirListFS{http.Dir(path)}))
 	return themeFilesHandler
 }
 

--- a/pkg/http/theme.go
+++ b/pkg/http/theme.go
@@ -135,6 +135,8 @@ type noDirListFS struct {
 	http.FileSystem
 }
 
+// Open returns 404 for dotfiles and directories; otherwise delegates to the
+// underlying FileSystem.
 func (fs noDirListFS) Open(name string) (http.File, error) {
 	for _, part := range strings.Split(name, "/") {
 		if strings.HasPrefix(part, ".") && part != "." {


### PR DESCRIPTION
## Summary

The theme HTTP handler used a bare `http.FileServer`, which generates and serves an HTML directory listing when the requested path is a directory and no `index.html` is present. Any alice-lg instance with a theme configured (`[theme] path = ...` in alice.conf) exposed a browseable directory listing at `<url_base>/` — revealing file names, sizes, and modification timestamps of the entire theme directory, including dotfiles that `listIncludes()` explicitly excludes.

The inconsistency: `listIncludes()` deliberately skips directories and dotfiles, but `Handler()` applied no equivalent filtering, so `http.FileServer` served them all.

**Only affects deployments with a theme configured.** Instances without a `[theme]` section in alice.conf are not affected.

## Changes

**`pkg/http/theme.go`**: Add `noDirListFS`, a custom `http.FileSystem` wrapper, and use it in `Handler()` instead of bare `http.Dir`.

`noDirListFS.Open()`:
- Returns `os.ErrNotExist` (HTTP 404) for any path segment beginning with `.` — blocks dotfiles (`.env`, `..data`, Kubernetes ConfigMap artefacts, etc.)
- Returns `os.ErrNotExist` for any directory open request — suppresses directory listing HTML

This aligns HTTP-serving behaviour with the existing `listIncludes()` filtering logic.

## Test plan

- [ ] `GET <url_base>/` returns HTTP 404 (previously returned directory listing HTML)
- [ ] `GET <url_base>/style.css` returns the file normally
- [ ] `GET <url_base>/.hidden` returns HTTP 404
- [ ] `GET <url_base>/subdir/` returns HTTP 404
- [ ] Stylesheet and script `<link>`/`<script>` tags injected by `StylesheetIncludes()` / `ScriptIncludes()` continue to load correctly
- [ ] Instance without `[theme]` configured is unaffected